### PR TITLE
Updating repository links to v8-archive

### DIFF
--- a/app/.github/ISSUE_TEMPLATE/config.yml
+++ b/app/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
   - name: Report Bug (API)
-    url: https://github.com/directus/api/issues/new?labels=bug&template=bug_report.md
+    url: https://github.com/directus/v8-archive/issues/new?labels=bug&template=bug_report.md
     about: Report a bug in the API and track its resolution
   - name: Request Feature
-    url: https://github.com/directus/directus/discussions/new
+    url: https://github.com/directus/v8-archive/discussions/new
     about: Request a feature to be added to the platform
   - name: Ask a Question
-    url: https://github.com/directus/directus/discussions/new
+    url: https://github.com/directus/v8-archive/discussions/new
     about: Ask questions and discuss with other community members
   - name: Report Security Vulnerability
-    url: https://github.com/directus/directus/security/policy
+    url: https://github.com/directus/v8-archive/security/policy
     about: Privately report security vulnerabilities

--- a/app/src/components/install/requirements.vue
+++ b/app/src/components/install/requirements.vue
@@ -163,7 +163,7 @@ export default {
 
 			try {
 				const githubVersionResponse = await axios.get(
-					'https://api.github.com/repos/directus/directus/tags'
+					'https://api.github.com/repos/directus/v8-archive/tags'
 				);
 				this.lastTag = githubVersionResponse.data.find(
 					tag => tag.name.includes('-') === false


### PR DESCRIPTION
This update is necessary to install directus now that the repository has been moved.